### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # Simple-Code
 Start of the year simple code practise
+[![Run on Repl.it](https://repl.it/badge/github/steo17054/Simple-Code)](https://repl.it/github/steo17054/Simple-Code)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@steo17054/Simple-Code-1).